### PR TITLE
dev: Poll by proxy

### DIFF
--- a/drivers/usb/gadget/xaptum/f_psock_gadget.c
+++ b/drivers/usb/gadget/xaptum/f_psock_gadget.c
@@ -329,6 +329,7 @@ static void psock_send_complete( struct usb_ep *ep, struct usb_request *req )
 	}
 }
 
+/* Recieves an incoming message from the host and passes it to the proxy */
 static void psock_read_complete( struct usb_ep *ep, struct usb_request *req )
 {
 

--- a/drivers/usb/gadget/xaptum/f_psock_gadget.c
+++ b/drivers/usb/gadget/xaptum/f_psock_gadget.c
@@ -303,7 +303,6 @@ static void psock_free_func( struct usb_function *f )
 
         usb_free_all_descriptors(f);
         kfree(func_to_psock(f));
-	
 }
 
 static int enable_endpoint( struct usb_composite_dev *cdev, struct f_psock *psock, struct usb_ep *ep )
@@ -330,7 +329,6 @@ static void psock_send_complete( struct usb_ep *ep, struct usb_request *req )
 	}
 	printk( "psock_gadget: completed sending msg\n" );
 }
-
 
 static void psock_read_complete( struct usb_ep *ep, struct usb_request *req )
 {

--- a/drivers/usb/gadget/xaptum/f_psock_gadget.c
+++ b/drivers/usb/gadget/xaptum/f_psock_gadget.c
@@ -327,7 +327,6 @@ static void psock_send_complete( struct usb_ep *ep, struct usb_request *req )
 	{
 		msg->state = MSG_SEND;
 	}
-	printk( "psock_gadget: completed sending msg\n" );
 }
 
 static void psock_read_complete( struct usb_ep *ep, struct usb_request *req )
@@ -338,8 +337,6 @@ static void psock_read_complete( struct usb_ep *ep, struct usb_request *req )
 	psock_proxy_msg_t *msg = kmalloc( sizeof( struct psock_proxy_msg ) , GFP_KERNEL );
 
 	psock_proxy_packet_to_msg(packet,msg);
-
-	printk( "Msg : %d %d %u\n", msg->type, msg->msg_id, msg->length );
 
 	if ( msg->length > req->length )
 	{
@@ -406,7 +403,6 @@ static int alloc_msg_read_request( struct usb_composite_dev *cdev, struct f_psoc
 {
 	struct usb_request *out_req;
 
-	printk( "Allocating msg request to read\n" );
 	out_req = usb_ep_alloc_request( psock->out_ep, GFP_ATOMIC );
 	out_req->length = sizeof( psock_proxy_msg_packet_t ) + PSOCK_GADGET_BUF_SIZE;
 	out_req->buf = kmalloc( out_req->length, GFP_ATOMIC );
@@ -460,7 +456,6 @@ static int enable_psock( struct usb_composite_dev *cdev, struct f_psock *psock )
 
 static void disable_psock(struct f_psock *psock )
 {
-	printk( "f_psock: disable_psock\n" );
 	if(psock)
 	{
 		usb_ep_disable(psock->in_ep);
@@ -500,7 +495,6 @@ static struct usb_function *psock_alloc(struct usb_function_instance *fi)
 	struct f_psock_opts *psock_opts;
 	struct f_psock *psock;
 
-	printk("Allocating psock function\n" );
 
 	psock = kzalloc( (sizeof *psock ), GFP_KERNEL );
 	if ( !psock )

--- a/drivers/usb/gadget/xaptum/f_psock_proxy.c
+++ b/drivers/usb/gadget/xaptum/f_psock_proxy.c
@@ -87,7 +87,7 @@ void f_psock_proxy_handle_in_msg( struct psock_proxy_msg *msg )
 	printk( KERN_INFO "f_psock_proxy: Got an incomming msg\n" );
 	if ( msg->type == F_PSOCK_MSG_ACTION_REPLY )
 	{
-		printk( KERN_INFO "f_psock_proxy: Got a reply\n" );
+		printk( KERN_INFO "f_psock_proxy: Got a reply on sock_id=%d\n", msg->sock_id );
 		struct psock_proxy_msg *orig = wait_list_get_msg_id( msg->msg_id );
 		if ( orig != NULL )
 		{
@@ -287,7 +287,7 @@ int f_psock_proxy_delete_socket( f_psock_proxy_socket_t *psk )
 
         psock_proxy_msg_t * msg = kzalloc( sizeof( psock_proxy_msg_t ) , GFP_KERNEL);
 
-	printk( "f_psock_proxy_delete_socket\n" );
+	printk( "f_psock_proxy_delete_socket sock_id=%d\n", psk->local_id );
        
        	msg->magic = PSOCK_MSG_MAGIC;	
 	msg->type = F_PSOCK_MSG_ACTION_REQUEST;
@@ -325,14 +325,13 @@ int f_psock_proxy_wait_answer( psock_proxy_msg_t *msg, psock_proxy_msg_t  **answ
 
 	if ( msg->state == MSG_ANSWERED )
 	{
-		printk( "Got an answer for socket msg\n" );
 		// Handle the result
 		*answermsg = msg->related;
 		res = 1;
 	}
 	else 
 	{
-		printk( KERN_ERR "psock_proxy: Got a timeout waiting for msg answer\n" );
+		printk( KERN_ERR "psock_proxy: Got a timeout waiting for msg answer on %d\n", msg->msg_id  );
 	}
 
 	// We can remove the item from the list now
@@ -456,12 +455,12 @@ int f_psock_proxy_poll_socket( f_psock_proxy_socket_t *psk)
 	int result = 0;
 	psock_proxy_msg_t * answer;
 
-	printk( "f_psock_proxy_poll_socket enter\n" );
+	printk( "f_psock_proxy_poll_socket enter for socket_id=%d\n",psk->local_id  );
 
 	/* If we are not currently polling then start */
 	if(!psk->is_poll)
 	{
-		printk( "f_psock_proxy_poll_socket starting poll\n" );
+		printk( "f_psock_proxy_poll_socket starting poll for socket_id=%d\n",psk->local_id );
 		psock_proxy_msg_t * msg = kzalloc( sizeof( psock_proxy_msg_t ) , GFP_KERNEL);
 		psk->is_poll = 1;
 	        msg->magic = PSOCK_MSG_MAGIC;	

--- a/drivers/usb/gadget/xaptum/f_psock_proxy.h
+++ b/drivers/usb/gadget/xaptum/f_psock_proxy.h
@@ -19,6 +19,7 @@
 typedef struct f_psock_proxy_socket
 {
         int local_id; // The local socket id for the socket
+        int is_poll; // Whether the host is already blocking to communicate.
 } f_psock_proxy_socket_t;
 
 /******************************************************************************************
@@ -56,6 +57,11 @@ int f_psock_proxy_write_socket( f_psock_proxy_socket_t *psk, void *data, size_t 
  * Read from the socket
  */
 int f_psock_proxy_read_socket( f_psock_proxy_socket_t *psk, void *data, size_t size );
+
+/**
+ * Poll from the socket
+ */
+int f_psock_proxy_poll_socket( f_psock_proxy_socket_t *psk);
 
 /************************************************************************************
  * API Fucntions towards the usb composite part of the driver

--- a/drivers/usb/gadget/xaptum/f_psock_socket.c
+++ b/drivers/usb/gadget/xaptum/f_psock_socket.c
@@ -208,8 +208,9 @@ static int f_psock_ioctl(struct socket *sock, unsigned int cmd, unsigned long ar
 static unsigned int f_psock_poll(struct file *file, struct socket *sock,
 				      struct poll_table_struct *wait)
 {
-	printk( KERN_ERR "f_psock_poll: Function not implemented\n" );
-	return POLLOUT | POLLIN;
+	struct f_psock_pinfo *psk = (struct f_psock_pinfo *)sock->sk;
+
+	return f_psock_proxy_poll_socket(&psk->psk);
 }
 /**
  * Operation definitions for the psock type
@@ -365,5 +366,3 @@ int f_psock_cleanup_sockets(void)
 	sock_unregister( f_psock_family_ops.family );
 	return 0;
 }
-
-

--- a/drivers/usb/gadget/xaptum/f_psock_socket.c
+++ b/drivers/usb/gadget/xaptum/f_psock_socket.c
@@ -117,7 +117,6 @@ static int f_psock_sock_sendmsg( struct socket *sock,
 
 	data = kmalloc( len, GFP_KERNEL );
 
-	printk( KERN_INFO "psock_socket: sendmsg :%d %ld\n", psk->psk.local_id, len );
 	r = copy_from_iter( data, len,  &msg->msg_iter);
 	if ( r < len )
 	{
@@ -139,7 +138,7 @@ static int f_psock_sock_recvmsg(struct socket *sock,
 	struct f_psock_pinfo *psk = (struct f_psock_pinfo *)sock->sk;
 	char *buf = kmalloc( size, GFP_KERNEL );
 
-	printk( KERN_INFO "psock_socket: recvmsg %d\n", psk->psk.local_id );
+	printk( KERN_INFO "psock_socket: recvmsg len=%d on sock_id=%d\n", size, psk->psk.local_id );
 
 	res = f_psock_proxy_read_socket( &psk->psk, buf, size );
 	

--- a/drivers/usb/gadget/xaptum/psock_proxy_msg.c
+++ b/drivers/usb/gadget/xaptum/psock_proxy_msg.c
@@ -25,5 +25,5 @@ void psock_proxy_packet_to_msg(psock_proxy_msg_packet_t *packet, psock_proxy_msg
     msg->state = le32_to_cpu(packet->state);
     msg->data = NULL;
     msg->related = NULL;
-    msg->wait_list = (const struct list_head){0};
+    msg->list_handle = (const struct list_head){0};
 }

--- a/drivers/usb/gadget/xaptum/psock_proxy_msg.h
+++ b/drivers/usb/gadget/xaptum/psock_proxy_msg.h
@@ -23,6 +23,7 @@ typedef enum psock_msg_type
 	F_PSOCK_MSG_ACTION_REQUEST, /**< Msg type for requesting an action to the other side */
 	F_PSOCK_MSG_ACTION_REPLY,   /**< Msg type for replying as a result of a requested action */
 	F_PSOCK_MSG_NONE,	    /**< Empty msg type (can be used to setup communication */
+	F_PSOCK_MSG_ASYNC,
 } psock_msg_type_t;
 
 /**
@@ -34,7 +35,8 @@ typedef enum psock_proxy_action
 	F_PSOCK_CONNECT,
 	F_PSOCK_READ,
 	F_PSOCK_WRITE,
-	F_PSOCK_CLOSE
+	F_PSOCK_CLOSE,
+	F_PSOCK_POLL
 } psock_proxy_action_t;
 
 /**

--- a/drivers/usb/gadget/xaptum/psock_proxy_msg.h
+++ b/drivers/usb/gadget/xaptum/psock_proxy_msg.h
@@ -78,7 +78,7 @@ typedef struct psock_proxy_msg
 	uint32_t state;
 	void * data;			/**< Holder necessary to both, but they have no relation between systems */
 	struct psock_proxy_msg *related;/**< f_psock only */
-	struct list_head wait_list;	/**< f_psock only */
+	struct list_head list_handle;	/**< f_psock only */
 } psock_proxy_msg_t;
 
 void psock_proxy_msg_to_packet(psock_proxy_msg_t *msg, psock_proxy_msg_packet_t *packet);


### PR DESCRIPTION
Still in development

This is the device side counterpart to the xaprc001 changes. This sends `F_PSOCK_POLL` messages to the host and accepts `F_PSOCK_MSG_ASYNC` messages. 

The procedure for polling is:
* If we are not currently polling this socket, send a poll message to the host
* If we currently have async messages to be read, return `POLLIN` (the flag indicating data is ready to be read)
* Otherwise return 0

The updated procedure for reading is
* If we are polling and there is async data, return the async data as if it were a regular read call
* If we are polling and there is no async data, return error instead of blocking
* If we are not polling do a regular read call. 

Reading an async message is similar to reading a response, except instead of checking it against a list of "waiting" messages it will be added to a list of asynchronous messages. This list will be checked during the read procedure. 