### PR TITLE
Open/Connect proper blocking

### DIFF
--- a/net/scm/xscm.c
+++ b/net/scm/xscm.c
@@ -108,6 +108,7 @@ int xaprc00x_sock_handle_shutdown(int sock_id)
 	psk = (struct xaprc00x_pinfo *) sk;
 
 	xaprc00x_sock_shutdown_internal(sk);
+	return 0;
 }
 EXPORT_SYMBOL_GPL(xaprc00x_sock_handle_shutdown);
 

--- a/net/scm/xscm.c
+++ b/net/scm/xscm.c
@@ -8,11 +8,12 @@
 #include <linux/net.h>
 #include <net/sock.h>
 #include <linux/xscm.h>
-#include "xscm_extern.h"
 #include <linux/rhashtable.h>
+#include <linux/sched/signal.h>
 
+#include "xscm_extern.h"
 #define XAPRC00X_SK_BUFF_SIZE 512
-#define XAPRC00X_SK_SND_TIMEO 1000
+#define XAPRC00X_SK_SND_TIMEO (HZ * 30)
 
 MODULE_LICENSE("GPL v2");
 MODULE_AUTHOR("Daniel Berliner");
@@ -27,6 +28,7 @@ enum xaprc00x_state {
 	SCM_UNOPEN=0, /* Initial state, unopened */
 	SCM_ESTABLISHED, /* Connection established */
 	SCM_SYN_SENT, /* Sent a connection request, waiting for ACK */
+	SCM_SYN_RECV, /* A connection request has been responded to but not processed */
 	SCM_CLOSING, /* Our side has closed, waiting for host */
 	SCM_CLOSE_WAIT, /* Remote has shut down and is waiting for us */
 	SCM_CLOSE, /* Close has been completed */
@@ -160,14 +162,13 @@ static void xaprc00x_def_readable(struct sock *sk)
  */
 void xaprc00x_sock_connect_ack(int sock_id, struct scm_packet *packet)
 {
-	int new_status;
 	struct socket_wq *wq;
 	struct xaprc00x_pinfo *psk;
 	struct sock *sk;
-	int status;
 
-	status = packet->ack.code;
-	psk = (struct xaprc00x_pinfo *) xaprc00x_get_sock(sock_id);
+	sk = xaprc00x_get_sock(sock_id);
+	psk = (struct xaprc00x_pinfo *) sk;
+	wq = rcu_dereference(sk->sk_wq);
 
 	/* This usually means the sock was shut down while in transit. */
 	if (!psk) {
@@ -176,48 +177,50 @@ void xaprc00x_sock_connect_ack(int sock_id, struct scm_packet *packet)
 		return;
 	}
 
-	sk = &psk->sk;
-
-	if (status == SCM_E_SUCCESS) {
-		new_status = SCM_ESTABLISHED;
-
-		/* Let poll know that we can write now */
-		sk->sk_write_space = xaprc00x_def_write_space;
-		sk->sk_data_ready = xaprc00x_def_readable;
-		sk->sk_write_space(&psk->sk);
-	} else {
-		new_status = SCM_CLOSE;
-
-		wq = rcu_dereference(sk->sk_wq);
-		wake_up_interruptible_all(&wq->wait);
-		sk_wake_async(sk, SOCK_WAKE_SPACE, POLL_OUT);
-	}
-
-	atomic_set(&psk->state, new_status);
-
-	/* Unblock the calling thread if it is waiting */
-	/* Either pass the reponse packet to the waiting call or free it now */
-	if(down_trylock(&psk->wait_sem)) {
-		psk->wait_ack = packet;
-	} else {
-		kfree(packet);
-	}
-	up(&psk->wait_sem);
-
+	/* Let the sock know we got a response */
+	psk->wait_ack = packet;
+	atomic_set(&psk->state, SCM_SYN_RECV);
+	wake_up_interruptible_all(&wq->wait);
 }
 EXPORT_SYMBOL_GPL(xaprc00x_sock_connect_ack);
 
+static long xaprc00x_wait_for_connect(struct sock *sk, long timeo)
+{
+	struct xaprc00x_pinfo *psk;
+
+	psk = (struct xaprc00x_pinfo *) sk;
+
+	DEFINE_WAIT_FUNC(wait, woken_wake_function);
+	add_wait_queue(sk_sleep(sk), &wait);
+
+	while (atomic_read(&psk->state) == SCM_SYN_SENT) {
+		release_sock(sk);
+		timeo = wait_woken(&wait, TASK_INTERRUPTIBLE, timeo);
+		lock_sock(sk);
+
+		if (signal_pending(current) || !timeo)
+			break;
+	}
+
+	remove_wait_queue(sk_sleep(sk), &wait);
+	return timeo;
+}
 /**
  * Funciton for sending a CONNECT
  */
 static int xaprc00x_sock_connect(struct socket *sock, struct sockaddr *addr,
 	int alen, int flags)
 {
-	int ret;
 	struct xaprc00x_pinfo *psk;
+	struct sock *sk;
 	int state;
+	int ret = -1;
 
-	psk = (struct xaprc00x_pinfo *)sock->sk;
+	sk = sock->sk;
+	psk = (struct xaprc00x_pinfo *)sk;
+
+	lock_sock(sk);
+
 	state = atomic_read(&psk->state);
 
 	if (state == SCM_SYN_SENT)
@@ -225,22 +228,46 @@ static int xaprc00x_sock_connect(struct socket *sock, struct sockaddr *addr,
 	else if (state == SCM_ESTABLISHED)
 		ret = -EISCONN;
 	else {
+		int new_status;
+		long timeo = sock_sndtimeo(sk, flags & O_NONBLOCK);
+
+		atomic_set(&psk->state, SCM_SYN_SENT);
 		scm_proxy_connect_socket(psk->local_id, addr, alen,
 			g_proxy_context);
-		atomic_set(&psk->state, SCM_SYN_SENT);
 
-		/* Block for ACK if nonblock isn't set */
-		if (!(flags & SOCK_NONBLOCK)) {
-			down(&psk->wait_sem);
-
-			ret = psk->wait_ack->ack.code;
-
-			/* The proxy expects us to free the buffer */
-			kfree(psk->wait_ack);
-			psk->wait_ack = NULL;
+		/* Exit immediately if asked not to block */
+		if(!timeo || !xaprc00x_wait_for_connect(sk, timeo)) {
+			ret = -EINPROGRESS;
+			goto out;
 		}
+
+		/* If interrupted the error is either -ERESTARTSYS or -EINTR */
+		ret = sock_intr_errno(timeo);
+		if (signal_pending(current))
+			goto out;
+
+		if (psk->wait_ack->ack.code == SCM_E_SUCCESS) {
+			new_status = SCM_ESTABLISHED;
+
+			/* Let poll know that we can write now */
+			sk->sk_write_space = xaprc00x_def_write_space;
+			sk->sk_data_ready = xaprc00x_def_readable;
+			sk->sk_write_space(&psk->sk);
+			ret = 0;
+		} else {
+			struct socket_wq *wq = rcu_dereference(sk->sk_wq);
+
+			new_status = SCM_CLOSE;
+
+			wake_up_interruptible_all(&wq->wait);
+			sk_wake_async(sk, SOCK_WAKE_SPACE, POLL_OUT);
+			ret = -1;
+		}
+		atomic_set(&psk->state, new_status);
 	}
 
+out:
+	release_sock(sk);
 	return ret;
 }
 

--- a/net/scm/xscm_extern.h
+++ b/net/scm/xscm_extern.h
@@ -1,6 +1,7 @@
 /* SCM Proxy external defs */
 extern void scm_proxy_close_socket(int local_id, void *context);
-extern int scm_proxy_open_socket(int *local_id, void *context);
+extern int scm_proxy_open_socket(int local_id, void *context);
 extern int scm_proxy_connect_socket(int local_id, struct sockaddr *addr,
 	int alen, void *context);
 extern void scm_proxy_wait_ack(struct scm_packet **packet, int msg_id);
+extern int scm_proxy_write_socket(int sock_id, void *msg, int len, void *context);


### PR DESCRIPTION
Instead of using semaphores the open and connect functions now use lock_sock and a kernel provided waitqueue to block. Connect is very similar to what INET sockets do, but OPEN is somewhat uncharted territory because no one else blocks. The same approach is taken in both. 